### PR TITLE
style: format json with prettier on save

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,12 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  }
 }


### PR DESCRIPTION
## Summary
- format JSON and JSONC files on save using Prettier
- recommend installing the Prettier VSCode extension

## Testing
- `pnpm lint` *(fails: @aviene/utils.types:lint: command finished with error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6084379ac8328bb66dcc6a29ac5f9